### PR TITLE
Include setup-python in ourselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: ci
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+      - run: platform --help

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
       - uses: freckle/setup-platform-action@main
       - run: platform container:login
       - run: platform container:push --tag ${{ github.sha }}

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ outputs: {}
 runs:
   using: composite
   steps:
+    # Needed so we can install cfn-flip
+    - uses: actions/setup-python@v2
     - shell: bash
       run: |
         ${{ github.action_path }}/bin/install \


### PR DESCRIPTION
When this Action was first created, you could not use other Actions via `uses` in composite definitions. This meant we asked our users to `setup-python` before using this, so we could install `cfn-flip`.

That limitation is gone, so we can call it ourselves now :tada: 

In the future, we will probably gate this on a check to see if Python is already adequately configured, so we don't over-configure in a Workflow where there needs to be a different and specific Python setup. But we'll defer that for now.