### PR TITLE
Simplify inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.runner }}
+    env:
+      # Dummy env so the CLI doesn't fail on initialization
+      AWS_ACCESS_KEY_ID: x
+      AWS_SECRET_ACCESS_KEY: x
 
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +30,11 @@ jobs:
 
   test-version-input:
     runs-on: ubuntu-latest
+    env:
+      # Dummy env so the CLI doesn't fail on initialization
+      AWS_ACCESS_KEY_ID: x
+      AWS_SECRET_ACCESS_KEY: x
+
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -40,6 +49,11 @@ jobs:
 
   test-version-inferred:
     runs-on: ubuntu-latest
+    env:
+      # Dummy env so the CLI doesn't fail on initialization
+      AWS_ACCESS_KEY_ID: x
+      AWS_SECRET_ACCESS_KEY: x
+
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,49 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - macOS-latest
+      fail-fast: false
+
+    runs-on: ${{ matrix.runner }}
+
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         with:
           token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
-      - run: platform --help
+      - run: |
+          platform version
+
+  test-version-input:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          version: v2.1.0.0
+          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+      - run: |
+          if [[ "v$(platform version)" != "v2.1.0.0" ]]; then
+            echo "Did not install desired version" >&2
+            exit 1
+          fi
+
+  test-version-inferred:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          mkdir -p .platform
+          echo "v2.1.0.0" > .platform/VERSION
+      - uses: ./
+        with:
+          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+      - run: |
+          if [[ "v$(platform version)" != "v2.1.0.0" ]]; then
+            echo "Did not install desired version" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
           version: v2.1.0.0
           token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
       - run: |
-          if [[ "v$(platform version)" != "v2.1.0.0" ]]; then
+          # Current version prints this to stderr, but we should fix that
+          if [[ "v$(platform version 2>&1)" != "v2.1.0.0" ]]; then
             echo "Did not install desired version" >&2
             exit 1
           fi
@@ -63,7 +64,7 @@ jobs:
         with:
           token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
       - run: |
-          if [[ "v$(platform version)" != "v2.1.0.0" ]]; then
+          if [[ "v$(platform version 2>&1)" != "v2.1.0.0" ]]; then
             echo "Did not install desired version" >&2
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: freckle/setup-platform-action@v5
+      - uses: freckle/setup-platform-action@v6
         with:
           token: ${{ secrets.X }}
       - run: platform container:login
@@ -27,7 +27,11 @@ jobs:
 
 - `version`: the version of Platform CLI to install.
 
-  See its [releases][] for available versions. Defaults to `latest`.
+  If not present, we look for a `.platform/VERSION` file and expect it to
+  contain the version to install. If no such file exists, we'll use the latest
+  Release.
+
+  See [`freckle/platform` Releases][releases] for available versions.
 
   [releases]: https://github.com/freckle/platform/releases
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ jobs:
 
   [releases]: https://github.com/freckle/platform/releases
 
-- `suffix`: artifact suffix to use
-
-  Must be `x86_64-linux` or `x86_64-osx`. Defaults to `x86_64-linux`.
-
 - `token`: a GitHub token with access to download artifacts from the private
   `freckle/platform` repository.
 

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,13 @@ runs:
       run: tar xzvf ./platform-${{ steps.prep.outputs.suffix }}.tar.gz
 
     - shell: bash
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        echo "Replacing BSD install with GNU install"
+        brew install coreutils
+        ln -sf "$(which ginstall)" "$(which install)"
+
+    - shell: bash
       run: cd ./platform && sudo make install
 
     - if: ${{ steps.prep.outputs.needs-cfn-flip == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,9 @@ runs:
       run: |
         echo "Replacing BSD install with GNU install"
         brew install coreutils
-        sudo ln -sf "$(which ginstall)" "$(which install)"
+        sudo mkdir -p /usr/local/bin
+        sudo ln -sf "$(which ginstall)" /usr/local/bin/install
+        install --version | grep -Fq GNU
 
     - shell: bash
       run: cd ./platform && sudo make install

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
         token: ${{ inputs.token }}
 
     - shell: bash
-      run: tar xzvf ./platform-${{ inputs.suffix }}.tar.gz
+      run: tar xzvf ./platform-${{ steps.prep.outputs.suffix }}.tar.gz
 
     - shell: bash
       run: cd ./platform && sudo make install

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       run: |
         echo "Replacing BSD install with GNU install"
         brew install coreutils
-        ln -sf "$(which ginstall)" "$(which install)"
+        sudo ln -sf "$(which ginstall)" "$(which install)"
 
     - shell: bash
       run: cd ./platform && sudo make install

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: Version of Platform CLI to install
     required: true
     default: ""
-  suffix:
-    description: OS-specific suffix for Platform package archive
-    required: true
-    default: x86_64-linux
   token:
     description: GitHub Token with access to freckle/platform repository
     required: true
@@ -16,24 +12,32 @@ outputs: {}
 runs:
   using: composite
   steps:
-    - uses: robinraju/release-downloader@v1.3
-      with:
-        repository: freckle/platform
-        latest: ${{ inputs.version == '' }}
-        tag: ${{ inputs.version }}
-        fileName: platform-${{ inputs.suffix }}.tar.gz
-        token: ${{ inputs.token }}
-
-    - shell: bash
-      run: tar xzvf ./platform-${{ inputs.suffix }}.tar.gz
-
-    - shell: bash
-      run: cd ./platform && sudo make install
-
-    - id: setup
+    - id: prep
       shell: bash
       run: |
-        case "${{ inputs.version }}" in
+        if [[ -f .platform/VERSION ]]; then
+          read -r version < .platform/VERSION
+        else
+          version=${{ inputs.version }}
+        fi
+
+        echo "::set-output name=version::$version"
+
+        case "${{ runner.os }}" in
+          Linux)
+            echo "::set-output name=suffix::x86_64-linux"
+            ;;
+          Windows)
+            echo "freckle/platform does not currently release for Windows" >&2
+            exit 1
+            ;;
+          macOS)
+            echo "::set-output name=suffix::x86_64-osx"
+            ;;
+        esac
+
+        # Install cfn-flip if the PlatformCLI version requested is old
+        case "$version" in
           v0* | v1* | v2.0*)
             echo "::set-output name=needs-cfn-flip::true"
             ;;
@@ -42,9 +46,23 @@ runs:
             ;;
         esac
 
-    - if: ${{ steps.setup.outputs.needs-cfn-flip == 'true' }}
+    - uses: robinraju/release-downloader@v1.3
+      with:
+        repository: freckle/platform
+        latest: ${{ steps.prep.outputs.version == '' }}
+        tag: ${{ steps.prep.outputs.version }}
+        fileName: platform-${{ steps.prep.outputs.suffix }}.tar.gz
+        token: ${{ inputs.token }}
+
+    - shell: bash
+      run: tar xzvf ./platform-${{ inputs.suffix }}.tar.gz
+
+    - shell: bash
+      run: cd ./platform && sudo make install
+
+    - if: ${{ steps.prep.outputs.needs-cfn-flip == 'true' }}
       uses: actions/setup-python@v2
 
-    - if: ${{ steps.setup.outputs.needs-cfn-flip == 'true' }}
+    - if: ${{ steps.prep.outputs.needs-cfn-flip == 'true' }}
       shell: bash
       run: pip install cfn-flip


### PR DESCRIPTION
Trying to make this thing simpler to use. These change should make it
most common to just `uses:` it without anything else.

- Support `.platform/VERSION` instead of `inputs.version`
- Just work out `suffix` by `os.runner`
- Add tests for these behaviors

Ultimately, I'm thinking about taking the internal setup call out of our
build-and-push and deploy actions and making callers do it themselves.
This is because I think the token-passing of the latest version is confusing
if not done directly at top level.

Right now, we'll have to do a lot of:

```diff
 - uses: freckle/platform-deploy-action
   with:
    platform-version: X
+   platform-setup-token: ${{ secrets.X }}
```

So I'm considering if this isn't so much worse but is nicely explicit:

```diff
+- uses: freckle/setup-platform-action
+  with:
+    version: x
+    token: ${{ secrets.X }}
 - uses: freckle/platform-deploy-action
-  with:
-    platform-version: X
```