### PR TITLE
Export SLACK_ variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Or deploy
 - run: platform deploy --tag '${{ steps.setup.outputs.tag }}'
 ```
 
+We also export various `SLACK_*` environment variables, so you don't have to set
+as much when notifying via the `rtCamp` action:
+
+```yaml
+- if: ${{ always() }}
+  uses: rtCamp/action-slack-notify@v2
+  env:
+    # Only this is now required
+    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    # But you probably want this too
+    SLACK_COLOR: ${{ github.action_status }}
+    SLACK_MESSAGE: ${{ github.action_status }}
+```
+
 ## Stackctl
 
 The action also installs a `stackctl` executable and configures `STACKCTL_*`

--- a/action.yml
+++ b/action.yml
@@ -132,3 +132,28 @@ runs:
         key: ${{ runner.os }}-${{ github.job }}-${{ steps.set-tag.outputs.tag }}
         restore-keys: |
           ${{ runner.os }}-${{ github.job }}-
+
+    - name: Configure Slack notification ENV
+      shell: bash
+      run: |
+        title="deploy"
+
+        if [[ -n "$PLATFORM_RESOURCE" ]]; then
+          title="$PLATFORM_RESOURCE $title"
+        fi
+
+        if [[ -n "$PLATFORM_ENVIRONMENT" ]]; then
+          title="$PLATFORM_ENVIRONMENT $title"
+        fi
+
+        if [[ -n "$PLATFORM_APP" ]]; then
+          title="$PLATFORM_APP $title"
+        fi
+
+        cat <<EOM >>"$GITHUB_ENV"
+        SLACK_ICON=https://github.com/freckle-automation.png?size=48
+        SLACK_USERNAME=GitHub Actions
+        SLACK_TITLE=$title
+        SLACK_FOOTER=${{ steps.set-tag.outputs.tag }}
+        MSG_MINIMAL=actions url,commit
+        EOM

--- a/test/configured.bats
+++ b/test/configured.bats
@@ -18,3 +18,7 @@ load /usr/lib/bats-assert/load
   assert_equal "$PLATFORM_RESOURCE" "my-resource"
   assert_equal "$PLATFORM_NO_VALIDATE" "1"
 }
+
+@test "Slack notification ENV" {
+  assert_equal "$SLACK_TITLE" "my-app dev my-resource deploy"
+}

--- a/test/defaults.bats
+++ b/test/defaults.bats
@@ -27,6 +27,14 @@ load /usr/lib/bats-assert/load
   assert_equal "$PLATFORM_NO_VALIDATE" ""
 }
 
+@test "Slack notification ENV" {
+  assert_equal "$SLACK_ICON" "https://github.com/freckle-automation.png?size=48"
+  assert_equal "$SLACK_USERNAME" "GitHub Actions"
+  assert_equal "$SLACK_TITLE" "deploy"
+  assert_equal "$SLACK_FOOTER" "$TAG"
+  assert_equal "$MSG_MINIMAL" "actions url,commit"
+}
+
 @test "tag" {
   assert test -n "$TAG"
 


### PR DESCRIPTION
As described in the new README section, this makes it less cumbersome to
use the `rtCamp` action directly. This was the only other feature of the
`platform-deploy-action` that we're trying to obviate.

Before, one action did setup/deploy/notify:

```yaml
- uses: platform-deploy-action
  with:
    platform-setup-token: x
    platform-version: y
    environment: z
    slack-url: w
```

Now, we have more composable pieces:

```yaml
- uses: setup-platform-action
  with:
    token: x
    version: y
    environment: z

- run: platform deploy --tag '...'

- uses: rtCamp/action-slack-notify
  with:
    SLACK_WEBHOOK: w
```

This is only _slightly_ more work for the end-user, but there's way less
stuff hiding behind the scenes. It's more transparent and flexible this
way. That's the hope anyway.