### PR TITLE
Rename app input to app-directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
         with:
           token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
           version: "2.1.0.0"
+          app-directory: my-app
           environment: dev
-          app: my-app
           resource: my-resource
           no-validate: "1"
           stackctl-version: "1.1.4.0"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ outside Freckle.
 
     # Optional
     # version: 2.5.0.1
+    # app-directory: my-app     # If in multi-app repository
     # environment: prod
-    # app: my-app               # If in multi-app repository
     # resource: my-resource     # If in multi-resource app
     # stackctl-version: 1.3.0.1
 ```
@@ -95,12 +95,13 @@ you can do things like post changeset details to our PR:
   stable version. We recommend using this default, along with specifying a
   `required_version` in your `.platform.yaml`.
 
+- **app-directory**: if present, this will be set as `PLATFORM_APP_DIRECTORY`
+  for the remainder of the workflow. For details on what this affects, see
+  `platform(1)`.
+
 - **environment**: if present, this will be set as `PLATFORM_ENVIRONMENT` for
   the remainder of the workflow. For details on what this affects, see
   `platform(1)`.
-
-- **app**: if present, this will be set as `PLATFORM_APP` for the remainder of
-  the workflow. For details on what this affects, see `platform(1)`.
 
 - **resource**: if present, this will be set as `PLATFORM_RESOURCE` for the
   remainder of the workflow. For details on what this affects, see

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ outside Freckle.
     token: ${{ secrets.X }}
 
     # Optional
-    # version: 2.5.0.1
+    # version: 2.5.1.0
     # app-directory: my-app     # If in multi-app repository
     # environment: prod
     # resource: my-resource     # If in multi-resource app

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: Version of Platform CLI to install
     required: true
-    default: "2.5.0.1"
+    default: "2.5.1.0"
 
   token:
     description: GitHub Token with access to freckle/platform repository

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,13 @@ inputs:
     description: GitHub Token with access to freckle/platform repository
     required: true
 
-  environment:
-    description: Value to set as PLATFORM_ENVIRONMENT
+  app-directory:
+    description: Value to set as PLATFORM_APP_DIRECTORY
     required: true
     default: ""
 
-  app:
-    description: Value to set as PLATFORM_APP
+  environment:
+    description: Value to set as PLATFORM_ENVIRONMENT
     required: true
     default: ""
 
@@ -83,8 +83,8 @@ runs:
           echo 'LOG_DESTINATION=stderr'
           echo 'STACKCTL_DIRECTORY=.platform/specs'
 
-          if [[ -n "${{ inputs.app }}" ]]; then
-            echo 'PLATFORM_APP=${{ inputs.app }}'
+          if [[ -n "${{ inputs.app-directory }}" ]]; then
+            echo 'PLATFORM_APP_DIRECTORY=${{ inputs.app-directory }}'
           fi
 
           if [[ -n "${{ inputs.environment }}" ]]; then
@@ -121,7 +121,7 @@ runs:
       name: Set cache ouput
       shell: bash
       run: |
-        app=${{ inputs.app }}
+        app=${{ inputs.app-directory }}
         app=${app:-.}
         echo "cache=$app/.platform/cache" >>"$GITHUB_OUTPUT"
 
@@ -146,8 +146,8 @@ runs:
           title="$PLATFORM_ENVIRONMENT $title"
         fi
 
-        if [[ -n "$PLATFORM_APP" ]]; then
-          title="$PLATFORM_APP $title"
+        if [[ -n "$PLATFORM_APP_DIRECTORY" ]]; then
+          title="$PLATFORM_APP_DIRECTORY $title"
         fi
 
         cat <<EOM >>"$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
       name: Set cache ouput
       shell: bash
       run: |
-        app=${{ inputs.app-directory }}
+        app=$PLATFORM_APP_DIRECTORY
         app=${app:-.}
         echo "cache=$app/.platform/cache" >>"$GITHUB_OUTPUT"
 

--- a/test/configured.bats
+++ b/test/configured.bats
@@ -13,7 +13,7 @@ load /usr/lib/bats-assert/load
 # }
 
 @test "PlatformCLI ENV" {
-  assert_equal "$PLATFORM_APP" "my-app"
+  assert_equal "$PLATFORM_APP_DIRECTORY" "my-app"
   assert_equal "$PLATFORM_ENVIRONMENT" "dev"
   assert_equal "$PLATFORM_RESOURCE" "my-resource"
   assert_equal "$PLATFORM_NO_VALIDATE" "1"

--- a/test/defaults.bats
+++ b/test/defaults.bats
@@ -3,7 +3,7 @@ load /usr/lib/bats-assert/load
 
 @test "PlatformCLI version" {
   run platform version
-  assert_output "PlatformCLI v2.5.0.1"
+  assert_output "PlatformCLI v2.5.1.0"
 }
 
 @test "Stackctl version" {

--- a/test/defaults.bats
+++ b/test/defaults.bats
@@ -21,7 +21,7 @@ load /usr/lib/bats-assert/load
 }
 
 @test "PlatformCLI ENV" {
-  assert_equal "$PLATFORM_APP" ""
+  assert_equal "$PLATFORM_APP_DIRECTORY" ""
   assert_equal "$PLATFORM_ENVIRONMENT" ""
   assert_equal "$PLATFORM_RESOURCE" ""
   assert_equal "$PLATFORM_NO_VALIDATE" ""


### PR DESCRIPTION
We decided to go with that in PlatformCLI, since this is more about the
working directory and not the (for example) name of the App or
something.

---

This will require PlatformCLI v2.5.1.0 to work, ~which I'll update the default `version` to~ done. This really
ought to be a major version bump, but as this is an "us" action and it's not really adopted yet, I think
I'd like to just keep this in the `@v7` line.