### PR TITLE
Improvements for primarily-Stackctl use-cases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,11 @@ inputs:
     required: true
     default: "1.4.0.0"
 
+  stackctl-directory:
+    description: Value to set as STACKCTL_DIRECTORY
+    required: true
+    default: .platform/specs
+
 outputs:
   tag:
     value: ${{ steps.set-tag.outputs.tag }}
@@ -81,7 +86,6 @@ runs:
         {
           echo 'LOG_COLOR=always'
           echo 'LOG_DESTINATION=stderr'
-          echo 'STACKCTL_DIRECTORY=.platform/specs'
 
           if [[ -n "${{ inputs.app-directory }}" ]]; then
             echo 'PLATFORM_APP_DIRECTORY=${{ inputs.app-directory }}'
@@ -97,6 +101,12 @@ runs:
 
           if [[ -n "${{ inputs.no-validate }}" ]]; then
             echo 'PLATFORM_NO_VALIDATE=${{ inputs.no-validate }}'
+          fi
+
+          if [[ -n "${{ inputs.stackctl-directory }}" ]]; then
+            app=${{ inputs.app-directory }}
+            app=${app:-.}
+            echo "STACKCTL_DIRECTORY=$app/${{ inputs.stackctl-directory }}"
           fi
 
         } >>"$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -156,18 +156,18 @@ runs:
     - name: Configure Slack notification ENV
       shell: bash
       run: |
-        title="deploy"
+        title="Deploy"
 
-        if [[ -n "$PLATFORM_RESOURCE" ]]; then
-          title="$PLATFORM_RESOURCE $title"
+        if [[ -n "$PLATFORM_APP_DIRECTORY" ]] && [[ -n "$PLATFORM_RESOURCE" ]]; then
+          title+=" $PLATFORM_APP_DIRECTORY/$PLATFORM_RESOURCE"
+        elif [[ -n "$PLATFORM_APP_DIRECTORY" ]]; then
+          title+=" $PLATFORM_APP_DIRECTORY"
+        elif [[ -n "$PLATFORM_RESOURCE" ]]; then
+          title+=" $PLATFORM_RESOURCE"
         fi
 
         if [[ -n "$PLATFORM_ENVIRONMENT" ]]; then
-          title="$PLATFORM_ENVIRONMENT $title"
-        fi
-
-        if [[ -n "$PLATFORM_APP_DIRECTORY" ]]; then
-          title="$PLATFORM_APP_DIRECTORY $title"
+          title+=" to $PLATFORM_ENVIRONMENT"
         fi
 
         cat <<EOM >>"$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
     required: true
     default: .platform/specs
 
+  stackctl-filter:
+    description: Value to set as STACKCTL_FILTER
+    required: true
+    default: ""
+
 outputs:
   tag:
     value: ${{ steps.set-tag.outputs.tag }}
@@ -107,6 +112,11 @@ runs:
             app=${{ inputs.app-directory }}
             app=${app:-.}
             echo "STACKCTL_DIRECTORY=$app/${{ inputs.stackctl-directory }}"
+          fi
+
+          if [[ -n "${{ inputs.stackctl-filter }}" ]]; then
+            echo "STACKCTL_FILTER=${{ inputs.stackctl-filter }}"
+            echo "STACKCTL_FILTERS=${{ inputs.stackctl-filter }}"
           fi
 
         } >>"$GITHUB_ENV"

--- a/test/configured.bats
+++ b/test/configured.bats
@@ -24,5 +24,5 @@ load /usr/lib/bats-assert/load
 }
 
 @test "Slack notification ENV" {
-  assert_equal "$SLACK_TITLE" "my-app dev my-resource deploy"
+  assert_equal "$SLACK_TITLE" "Deploy my-app/my-resource to dev"
 }

--- a/test/configured.bats
+++ b/test/configured.bats
@@ -12,6 +12,10 @@ load /usr/lib/bats-assert/load
 #   assert_output "Stackctl v1.1.4.0"
 # }
 
+@test "Stackctl ENV" {
+  assert_equal "$STACKCTL_DIRECTORY" my-app/.platform/specs
+}
+
 @test "PlatformCLI ENV" {
   assert_equal "$PLATFORM_APP_DIRECTORY" "my-app"
   assert_equal "$PLATFORM_ENVIRONMENT" "dev"

--- a/test/defaults.bats
+++ b/test/defaults.bats
@@ -30,7 +30,7 @@ load /usr/lib/bats-assert/load
 @test "Slack notification ENV" {
   assert_equal "$SLACK_ICON" "https://github.com/freckle-automation.png?size=48"
   assert_equal "$SLACK_USERNAME" "GitHub Actions"
-  assert_equal "$SLACK_TITLE" "deploy"
+  assert_equal "$SLACK_TITLE" "Deploy"
   assert_equal "$SLACK_FOOTER" "$TAG"
   assert_equal "$MSG_MINIMAL" "actions url,commit"
 }

--- a/test/defaults.bats
+++ b/test/defaults.bats
@@ -17,7 +17,7 @@ load /usr/lib/bats-assert/load
 }
 
 @test "Stackctl ENV" {
-  assert_equal "$STACKCTL_DIRECTORY" .platform/specs
+  assert_equal "$STACKCTL_DIRECTORY" ./.platform/specs
 }
 
 @test "PlatformCLI ENV" {


### PR DESCRIPTION
### [Add stackctl-directory input](https://github.com/freckle/setup-platform-action/pull/13/commits/c946ddc95692dfebd6a36f18031b4c2bae8643d5)
[c946ddc](https://github.com/freckle/setup-platform-action/pull/13/commits/c946ddc95692dfebd6a36f18031b4c2bae8643d5)

Also fixes a bug where `my-app` wouldn't be respected for the
`.platform/specs` location. Attempts to work with PlatformCLI-generated
stacks with `stackctl` in the case of a monorepository would've failed.

### [Add input for stackctl-filter](https://github.com/freckle/setup-platform-action/pull/13/commits/31126c7fb07e9447bda09bdc5fbbea0c9d5c2db2)
[31126c7](https://github.com/freckle/setup-platform-action/pull/13/commits/31126c7fb07e9447bda09bdc5fbbea0c9d5c2db2)

We export both `_FILTER` and `_FILTERS` because Stackctl has a bug and
is looking for the wrong environment variable name. Exporting both will
ensure it works now and once fixed. Our own input and the documentation
reflects the desired (although currently inaccurate) value.

### [Improve SLACK_TITLE](https://github.com/freckle/setup-platform-action/pull/13/commits/e8aed5ca02d04ec8fbbdb5885e17b3e52a3b6141)