### PR TITLE
Cache according to resource input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,19 +138,24 @@ runs:
         echo "tag=$tag" >>"$GITHUB_OUTPUT"
 
     - id: set-cache
-      name: Set cache ouput
+      name: Set cache path output and resource
       shell: bash
       run: |
         app=$PLATFORM_APP_DIRECTORY
         app=${app:-.}
         echo "cache=$app/.platform/cache" >>"$GITHUB_OUTPUT"
 
+        resource=$PLATFORM_RESOURCE
+        resource=${resource:-all-resources}
+        echo "resource=$resource" >>"$GITHUB_OUTPUT"
+
     - name: Cache .platform/cache directory
       uses: actions/cache@v3
       with:
         path: ${{ steps.set-cache.outputs.cache }}
-        key: ${{ runner.os }}-${{ github.job }}-${{ steps.set-tag.outputs.tag }}
+        key: ${{ runner.os }}-${{ github.job }}-${{ steps.set-cache.outputs.resource }}-${{ steps.set-tag.outputs.tag }}
         restore-keys: |
+          ${{ runner.os }}-${{ github.job }}-${{ steps.set-cache.outputs.resource }}-
           ${{ runner.os }}-${{ github.job }}-
 
     - name: Configure Slack notification ENV


### PR DESCRIPTION
When this action is used in a matrix, only one of the jobs will successfully write to the cache. This can be observed in `freckle/progress`, where runs of `progress (db)` and `progress (api)` show the same cache being restored, but the latter job unable to write to the cache. This is because the `job_id` is constant across matrix runs.

Although we'd like to consolidate this deploy into a single job, I think this is unexpected and can be addressed by using the `resource` input in the cache key. In that repo, future runs would get distinct caches for the `api` and `db` resources. This should also preserve caches where this action is used without a `resource` key, using the `restore-keys` function of the cache action.