### PR TITLE
Add scheduled workflow to maintain tool defaults

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,67 @@
+name: Bump
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily
+
+  # test changes to this file itself
+  pull_request:
+    paths:
+      - .github/workflows/bump.yml
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        tool:
+          - platform
+          - stackctl
+
+        include:
+          - tool: platform
+            input: version
+          - tool: stackctl
+            input: stackctl-version
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: current
+        name: "Determine current ${{ matrix.input }} default"
+        uses: mikefarah/yq
+        with:
+          cmd: yq ".inputs.${{ matrix.input }}.default" action.yml
+
+      - id: latest
+        name: "Determine latest ${{ matrix.tool }} release"
+        run: |
+          {
+            printf 'result='
+            gh --repo "freckle/${{ matrix.tool }}" release view \
+              --json tagName \
+              --jq .tagName | sed 's/^v//'
+          } >>"$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+
+      - if: ${{ steps.current.outputs.result != steps.latest.outputs.result }}
+        run: |
+          printf '%s: current %s is out of date (%s => %s)\n' "$TOOL" "$INPUT" "$CURRENT" "$LATEST"
+          find . -type f -exec sed -i.$$.bak "s/$CURRENT/$LATEST/g" {} +
+          find . -type f -name "*.$$.bak" -delete
+        env:
+          TOOL: ${{ matrix.tool }}
+          INPUT: ${{ matrix.input }}
+          CURRENT: ${{ steps.current.outputs.result }}
+          LATEST: ${{ steps.latest.outputs.result }}
+
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          # Use PAT so this will trigger test/lint on the created PR
+          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+          commit-message: |
+            Update ${{ matrix.input }} to latest ${{ matrix.tool }} release
+          title: |
+            Update ${{ matrix.input }} to latest ${{ matrix.tool }} release

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -30,7 +30,7 @@ jobs:
 
       - id: current
         name: "Determine current ${{ matrix.input }} default"
-        uses: mikefarah/yq
+        uses: mikefarah/yq@v4.35.1
         with:
           cmd: yq ".inputs.${{ matrix.input }}.default" action.yml
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           # Use PAT so this will trigger test/lint on the created PR
           token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+          base: main
           commit-message: |
             Update ${{ matrix.input }} to latest ${{ matrix.tool }} release
           title: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -57,11 +57,12 @@ jobs:
           CURRENT: ${{ steps.current.outputs.result }}
           LATEST: ${{ steps.latest.outputs.result }}
 
-      - uses: peter-evans/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@v5
         with:
           # Use PAT so this will trigger test/lint on the created PR
           token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
           base: main
+          branch: create-pull-request/bump-${{ matrix.tool }}
           commit-message: |
             Update ${{ matrix.input }} to latest ${{ matrix.tool }} release
           title: |


### PR DESCRIPTION
This workflow is basically the existing `bin/bump` in Workflow form. It looks at the defined defaults for `version` and `stackctl-version` and updates them (anywhere those values appear) with the latest release, if different. It then opens a PR to trigger review and merge.

This should help us avoid releasing new versions and forgetting to update the defaults of this action to them.