### PR TITLE
Support github-app inputs instead of token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+          github-app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
+          github-app-private-key: ${{ secrets.FRECKLE_AUTOMATION_APP_PRIVATE_KEY }}
       - run: platform version
       - run: stackctl version
 
@@ -32,7 +33,8 @@ jobs:
       - id: setup
         uses: ./
         with:
-          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+          github-app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
+          github-app-private-key: ${{ secrets.FRECKLE_AUTOMATION_APP_PRIVATE_KEY }}
       - uses: bats-core/bats-action@2.0.0
         with:
           support-path: /usr/lib/bats/bats-support
@@ -55,9 +57,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - id: setup
+        uses: ./
         with:
-          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
+          github-app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
+          github-app-private-key: ${{ secrets.FRECKLE_AUTOMATION_APP_PRIVATE_KEY }}
           version: "2.1.0.0"
           app-directory: my-app
           environment: dev

--- a/README.md
+++ b/README.md
@@ -88,18 +88,20 @@ you can do things like post changeset details to your PR:
 
 ## Inputs
 
-| name                  | description                                                                                                                                                                                                                                                                                                  | required | default           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------- |
-| `version`             | <p>The version of PlatformCLI to install. Do not include the <code>v</code> prefix here. The default is to lookup the latest release. We recommend using this default, along with specifying a <code>required_version</code> constraint (such as <code>=~ 3</code>) in your <code>.platform.yaml</code>.</p> | `false`  | `""`              |
-| `token`               | <p>A GitHub access token with rights to fetch the private PlatformCLI release artifacts. There is an Organization-level secret for <code>freckle</code> repositories.</p>                                                                                                                                    | `true`   | `""`              |
-| `app-directory`       | <p>If present, this will be set as <code>PLATFORM_APP_DIRECTORY</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                | `false`  | `""`              |
-| `environment`         | <p>If present, this will be set as <code>PLATFORM_ENVIRONMENT</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
-| `resource`            | <p>If present, this will be set as <code>PLATFORM_RESOURCE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                     | `false`  | `""`              |
-| `no-validate`         | <p>If present, this will be set as <code>PLATFORM_NO_VALIDATE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
-| `stackctl-version`    | <p>The version of Stackctl to install. Do not include the <code>v</code> prefix here. The default will change over time, and is meant to be kept up with latest as best we can.</p>                                                                                                                          | `false`  | `""`              |
-| `stackctl-directory`  | <p>Value to set as STACKCTL_DIRECTORY</p>                                                                                                                                                                                                                                                                    | `false`  | `.platform/specs` |
-| `stackctl-filter`     | <p>Value to set as STACKCTL_FILTER</p>                                                                                                                                                                                                                                                                       | `false`  | `""`              |
-| `fetch-platform-yaml` | <p>Automatically fetch .platform.yaml via GitHub API if not present. This can be useful to avoid a checkout if all your Job needs is this file.</p>                                                                                                                                                          | `false`  | `true`            |
+| name                     | description                                                                                                                                                                                                                                                                                                  | required | default           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------- |
+| `version`                | <p>The version of PlatformCLI to install. Do not include the <code>v</code> prefix here. The default is to lookup the latest release. We recommend using this default, along with specifying a <code>required_version</code> constraint (such as <code>=~ 3</code>) in your <code>.platform.yaml</code>.</p> | `false`  | `""`              |
+| `token`                  | <p>A GitHub access token with rights to fetch the private PlatformCLI release artifacts. Either this or <code>github-app-{id,private-key}</code> must be given.</p>                                                                                                                                          | `false`  | `""`              |
+| `github-app-id`          | <p>If <code>token</code> is not provided, and this and <code>github-app-private-key</code> will be used to generate one scoped to the platform and stackctl repositories.</p>                                                                                                                                | `false`  | `""`              |
+| `github-app-private-key` | <p>If <code>token</code> is not provided, and this and <code>github-app-id</code> will be used to generate one scoped to the platform and stackctl repositories.</p>                                                                                                                                         | `false`  | `""`              |
+| `app-directory`          | <p>If present, this will be set as <code>PLATFORM_APP_DIRECTORY</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                | `false`  | `""`              |
+| `environment`            | <p>If present, this will be set as <code>PLATFORM_ENVIRONMENT</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
+| `resource`               | <p>If present, this will be set as <code>PLATFORM_RESOURCE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                     | `false`  | `""`              |
+| `no-validate`            | <p>If present, this will be set as <code>PLATFORM_NO_VALIDATE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
+| `stackctl-version`       | <p>The version of Stackctl to install. Do not include the <code>v</code> prefix here. The default will change over time, and is meant to be kept up with latest as best we can.</p>                                                                                                                          | `false`  | `""`              |
+| `stackctl-directory`     | <p>Value to set as STACKCTL_DIRECTORY</p>                                                                                                                                                                                                                                                                    | `false`  | `.platform/specs` |
+| `stackctl-filter`        | <p>Value to set as STACKCTL_FILTER</p>                                                                                                                                                                                                                                                                       | `false`  | `""`              |
+| `fetch-platform-yaml`    | <p>Automatically fetch .platform.yaml via GitHub API if not present. This can be useful to avoid a checkout if all your Job needs is this file.</p>                                                                                                                                                          | `false`  | `true`            |
 
 <!-- action-docs-inputs action="action.yml" -->
 
@@ -132,10 +134,23 @@ you can do things like post changeset details to your PR:
 
     token:
     # A GitHub access token with rights to fetch the private PlatformCLI release
-    # artifacts. There is an Organization-level secret for `freckle`
-    # repositories.
+    # artifacts. Either this or `github-app-{id,private-key}` must be given.
     #
-    # Required: true
+    # Required: false
+    # Default: ""
+
+    github-app-id:
+    # If `token` is not provided, and this and `github-app-private-key` will be used
+    # to generate one scoped to the platform and stackctl repositories.
+    #
+    # Required: false
+    # Default: ""
+
+    github-app-private-key:
+    # If `token` is not provided, and this and `github-app-id` will be used to
+    # generate one scoped to the platform and stackctl repositories.
+    #
+    # Required: false
     # Default: ""
 
     app-directory:

--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ you can do things like post changeset details to your PR:
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------- |
 | `version`                | <p>The version of PlatformCLI to install. Do not include the <code>v</code> prefix here. The default is to lookup the latest release. We recommend using this default, along with specifying a <code>required_version</code> constraint (such as <code>=~ 3</code>) in your <code>.platform.yaml</code>.</p> | `false`  | `""`              |
 | `token`                  | <p>A GitHub access token with rights to fetch the private PlatformCLI release artifacts. Either this or <code>github-app-{id,private-key}</code> must be given.</p>                                                                                                                                          | `false`  | `""`              |
-| `github-app-id`          | <p>If <code>token</code> is not provided, and this and <code>github-app-private-key</code> will be used to generate one scoped to the platform and stackctl repositories.</p>                                                                                                                                | `false`  | `""`              |
-| `github-app-private-key` | <p>If <code>token</code> is not provided, and this and <code>github-app-id</code> will be used to generate one scoped to the platform and stackctl repositories.</p>                                                                                                                                         | `false`  | `""`              |
+| `github-app-id`          | <p>Provide this (and <code>github-app-private-key</code>) instead of <code>token</code> to generate and use one from the identified App.</p>                                                                                                                                                                 | `false`  | `""`              |
+| `github-app-private-key` | <p>Provide this (and <code>github-app-id</code>) instead of <code>token</code> to generate and use one from the identified App.</p>                                                                                                                                                                          | `false`  | `""`              |
 | `app-directory`          | <p>If present, this will be set as <code>PLATFORM_APP_DIRECTORY</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                | `false`  | `""`              |
 | `environment`            | <p>If present, this will be set as <code>PLATFORM_ENVIRONMENT</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
 | `resource`               | <p>If present, this will be set as <code>PLATFORM_RESOURCE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                     | `false`  | `""`              |
 | `no-validate`            | <p>If present, this will be set as <code>PLATFORM_NO_VALIDATE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
-| `stackctl-version`       | <p>The version of Stackctl to install. Do not include the <code>v</code> prefix here. The default will change over time, and is meant to be kept up with latest as best we can.</p>                                                                                                                          | `false`  | `""`              |
+| `stackctl-version`       | <p>The version of Stackctl to install. Do not include the <code>v</code> prefix here. The default is to lookup the latest release.</p>                                                                                                                                                                       | `false`  | `""`              |
 | `stackctl-directory`     | <p>Value to set as STACKCTL_DIRECTORY</p>                                                                                                                                                                                                                                                                    | `false`  | `.platform/specs` |
 | `stackctl-filter`        | <p>Value to set as STACKCTL_FILTER</p>                                                                                                                                                                                                                                                                       | `false`  | `""`              |
-| `fetch-platform-yaml`    | <p>Automatically fetch .platform.yaml via GitHub API if not present. This can be useful to avoid a checkout if all your Job needs is this file.</p>                                                                                                                                                          | `false`  | `true`            |
+| `fetch-platform-yaml`    | <p>Automatically fetch <code>.platform.yaml</code> via GitHub API if not present. This can be useful to avoid a checkout if all your Job needs is this file. This will always use <code>github.token</code>, regardless of our own <code>token</code> input.</p>                                             | `false`  | `true`            |
 
 <!-- action-docs-inputs action="action.yml" -->
 
@@ -109,10 +109,10 @@ you can do things like post changeset details to your PR:
 
 ## Outputs
 
-| name    | description                                                                                                                                                                                                                                                       |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tag`   | <p>A consistent, source-specific value that should be used throughout build/push/deploy actions. It's currently the head sha for <code>pull_request</code> events, the "after" sha <code>push</code> events, and <code>github.sha</code> for all other events</p> |
-| `cache` | <p>Path to the <code>.platform/cache</code> directory, for which we've setup an <code>actions/cache</code> step. This output is only useful if in a multi-app repository.</p>                                                                                     |
+| name    | description                                                                                                                                                                                                                                                           |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tag`   | <p>A consistent, source-specific value that should be used throughout build/push/deploy actions. It's currently the head sha for <code>pull_request</code> events, the "after" sha for <code>push</code> events, and <code>github.sha</code> for all other events</p> |
+| `cache` | <p>Path to the <code>.platform/cache</code> directory, for which we've setup an <code>actions/cache</code> step. This output is only useful if in a multi-app repository.</p>                                                                                         |
 
 <!-- action-docs-outputs action="action.yml" -->
 
@@ -140,15 +140,15 @@ you can do things like post changeset details to your PR:
     # Default: ""
 
     github-app-id:
-    # If `token` is not provided, and this and `github-app-private-key` will be used
-    # to generate one scoped to the platform and stackctl repositories.
+    # Provide this (and `github-app-private-key`) instead of `token` to generate
+    # and use one from the identified App.
     #
     # Required: false
     # Default: ""
 
     github-app-private-key:
-    # If `token` is not provided, and this and `github-app-id` will be used to
-    # generate one scoped to the platform and stackctl repositories.
+    # Provide this (and `github-app-id`) instead of `token` to generate and use
+    # one from the identified App.
     #
     # Required: false
     # Default: ""
@@ -183,8 +183,7 @@ you can do things like post changeset details to your PR:
 
     stackctl-version:
     # The version of Stackctl to install. Do not include the `v` prefix here.
-    # The default will change over time, and is meant to be kept up with latest
-    # as best we can.
+    # The default is to lookup the latest release.
     #
     # Required: false
     # Default: ""
@@ -202,8 +201,9 @@ you can do things like post changeset details to your PR:
     # Default: ""
 
     fetch-platform-yaml:
-    # Automatically fetch .platform.yaml via GitHub API if not present. This can
-    # be useful to avoid a checkout if all your Job needs is this file.
+    # Automatically fetch `.platform.yaml` via GitHub API if not present. This
+    # can be useful to avoid a checkout if all your Job needs is this file. This
+    # will always use `github.token`, regardless of our own `token` input.
     #
     # Required: false
     # Default: true

--- a/action.yml
+++ b/action.yml
@@ -18,14 +18,14 @@ inputs:
 
   github-app-id:
     description: |
-      If `token` is not provided, and this and `github-app-private-key` will be used
-      to generate one scoped to the platform and stackctl repositories.
+      Provide this (and `github-app-private-key`) instead of `token` to generate
+      and use one from the identified App.
     required: false
 
   github-app-private-key:
     description: |
-      If `token` is not provided, and this and `github-app-id` will be used to
-      generate one scoped to the platform and stackctl repositories.
+      Provide this (and `github-app-id`) instead of `token` to generate and use
+      one from the identified App.
     required: false
 
   app-directory:
@@ -55,8 +55,7 @@ inputs:
   stackctl-version:
     description: |
       The version of Stackctl to install. Do not include the `v` prefix here.
-      The default will change over time, and is meant to be kept up with latest
-      as best we can.
+      The default is to lookup the latest release.
     required: false
 
   stackctl-directory:
@@ -69,8 +68,9 @@ inputs:
 
   fetch-platform-yaml:
     description: |
-      Automatically fetch .platform.yaml via GitHub API if not present. This can
-      be useful to avoid a checkout if all your Job needs is this file.
+      Automatically fetch `.platform.yaml` via GitHub API if not present. This
+      can be useful to avoid a checkout if all your Job needs is this file. This
+      will always use `github.token`, regardless of our own `token` input.
     default: "true"
 
 outputs:
@@ -79,7 +79,7 @@ outputs:
     description: |
       A consistent, source-specific value that should be used throughout
       build/push/deploy actions. It's currently the head sha for `pull_request`
-      events, the "after" sha `push` events, and `github.sha` for all other
+      events, the "after" sha for `push` events, and `github.sha` for all other
       events
 
   cache:

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,20 @@ inputs:
   token:
     description: |
       A GitHub access token with rights to fetch the private PlatformCLI release
-      artifacts. There is an Organization-level secret for `freckle`
-      repositories.
-    required: true
+      artifacts. Either this or `github-app-{id,private-key}` must be given.
+    required: false
+
+  github-app-id:
+    description: |
+      If `token` is not provided, and this and `github-app-private-key` will be used
+      to generate one scoped to the platform and stackctl repositories.
+    required: false
+
+  github-app-private-key:
+    description: |
+      If `token` is not provided, and this and `github-app-id` will be used to
+      generate one scoped to the platform and stackctl repositories.
+    required: false
 
   app-directory:
     description: |
@@ -81,6 +92,28 @@ outputs:
 runs:
   using: composite
   steps:
+    - if: ${{ !inputs.token && !(inputs.github-app-id && inputs.github-app-private-key) }}
+      shell: bash
+      run: |
+        # Validate token or github-app inputs
+        echo "Either token or github-app-id/private-key must be provided" >&2
+        exit 1
+
+    - id: app-token
+      if: ${{ !inputs.token }}
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ inputs.github-app-id }}
+        private-key: ${{ inputs.github-app-private-key }}
+        repositories: platform,stackctl
+
+    - id: token
+      shell: bash
+      run: |
+        # Choose token output
+        token=${{ inputs.token || steps.app-token.outputs.token }}
+        echo "token=$token" >>"$GITHUB_OUTPUT"
+
     - if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: |
@@ -96,7 +129,7 @@ runs:
       run: |
         # Determine latest PlatformCLI version
         curl \
-          --header "Authorization: Bearer ${{ inputs.token }}" \
+          --header "Authorization: Bearer ${{ steps.token.outputs.token }}" \
           --silent \
           --show-error \
           --fail https://api.github.com/repos/freckle/platform/releases |
@@ -110,7 +143,7 @@ runs:
       run: |
         # Determine latest Stackctl version
         curl \
-          --header "Authorization: Bearer ${{ inputs.token }}" \
+          --header "Authorization: Bearer ${{ steps.token.outputs.token }}" \
           --silent \
           --show-error \
           --fail https://api.github.com/repos/freckle/stackctl/releases |
@@ -124,7 +157,7 @@ runs:
         name: platform
         version: ${{ inputs.version || steps.prep.outputs.version }}
         url: "https://github.com/freckle/{name}/releases/download/v{version}/{name}-{arch}-{os}.{ext}"
-        github-token: ${{ inputs.token }}
+        github-token: ${{ steps.token.outputs.token }}
         arch: x86_64
         os-darwin: osx
         subdir: "{name}"


### PR DESCRIPTION
If provided, these are used to generate a token using the identified
app. This makes it trivial for us to move off of our
`freckle-automation` user and onto the internal GitHub App for the same
purpose.