### PR TITLE
Rename github-private-key input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ./
         with:
           github-app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
-          github-app-private-key: ${{ secrets.FRECKLE_AUTOMATION_APP_PRIVATE_KEY }}
+          github-private-key: ${{ secrets.FRECKLE_AUTOMATION_PRIVATE_KEY }}
       - run: platform version
       - run: stackctl version
 
@@ -34,7 +34,7 @@ jobs:
         uses: ./
         with:
           github-app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
-          github-app-private-key: ${{ secrets.FRECKLE_AUTOMATION_APP_PRIVATE_KEY }}
+          github-private-key: ${{ secrets.FRECKLE_AUTOMATION_PRIVATE_KEY }}
       - uses: bats-core/bats-action@2.0.0
         with:
           support-path: /usr/lib/bats/bats-support
@@ -61,7 +61,7 @@ jobs:
         uses: ./
         with:
           github-app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
-          github-app-private-key: ${{ secrets.FRECKLE_AUTOMATION_APP_PRIVATE_KEY }}
+          github-private-key: ${{ secrets.FRECKLE_AUTOMATION_PRIVATE_KEY }}
           version: "2.1.0.0"
           app-directory: my-app
           environment: dev

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ you can do things like post changeset details to your PR:
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------- |
 | `version`                | <p>The version of PlatformCLI to install. Do not include the <code>v</code> prefix here. The default is to lookup the latest release. We recommend using this default, along with specifying a <code>required_version</code> constraint (such as <code>=~ 3</code>) in your <code>.platform.yaml</code>.</p> | `false`  | `""`              |
 | `token`                  | <p>A GitHub access token with rights to fetch the private PlatformCLI release artifacts. Either this or <code>github-app-{id,private-key}</code> must be given.</p>                                                                                                                                          | `false`  | `""`              |
-| `github-app-id`          | <p>Provide this (and <code>github-app-private-key</code>) instead of <code>token</code> to generate and use one from the identified App.</p>                                                                                                                                                                 | `false`  | `""`              |
-| `github-app-private-key` | <p>Provide this (and <code>github-app-id</code>) instead of <code>token</code> to generate and use one from the identified App.</p>                                                                                                                                                                          | `false`  | `""`              |
+| `github-app-id`          | <p>Provide this (and <code>github-private-key</code>) instead of <code>token</code> to generate and use one from the identified App.</p>                                                                                                                                                                     | `false`  | `""`              |
+| `github-private-key`     | <p>Provide this (and <code>github-app-id</code>) instead of <code>token</code> to generate and use one from the identified App.</p>                                                                                                                                                                          | `false`  | `""`              |
+| `github-app-private-key` | <p>Deprecated, use github-private-key</p>                                                                                                                                                                                                                                                                    | `false`  | `""`              |
 | `app-directory`          | <p>If present, this will be set as <code>PLATFORM_APP_DIRECTORY</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                | `false`  | `""`              |
 | `environment`            | <p>If present, this will be set as <code>PLATFORM_ENVIRONMENT</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                  | `false`  | `""`              |
 | `resource`               | <p>If present, this will be set as <code>PLATFORM_RESOURCE</code> for the remainder of the workflow. For details on what this affects, see <code>platform(1)</code>.</p>                                                                                                                                     | `false`  | `""`              |
@@ -140,15 +141,21 @@ you can do things like post changeset details to your PR:
     # Default: ""
 
     github-app-id:
-    # Provide this (and `github-app-private-key`) instead of `token` to generate
+    # Provide this (and `github-private-key`) instead of `token` to generate
     # and use one from the identified App.
     #
     # Required: false
     # Default: ""
 
-    github-app-private-key:
+    github-private-key:
     # Provide this (and `github-app-id`) instead of `token` to generate and use
     # one from the identified App.
+    #
+    # Required: false
+    # Default: ""
+
+    github-app-private-key:
+    # Deprecated, use github-private-key
     #
     # Required: false
     # Default: ""

--- a/action.yml
+++ b/action.yml
@@ -18,14 +18,18 @@ inputs:
 
   github-app-id:
     description: |
-      Provide this (and `github-app-private-key`) instead of `token` to generate
+      Provide this (and `github-private-key`) instead of `token` to generate
       and use one from the identified App.
     required: false
 
-  github-app-private-key:
+  github-private-key:
     description: |
       Provide this (and `github-app-id`) instead of `token` to generate and use
       one from the identified App.
+    required: false
+
+  github-app-private-key:
+    description: Deprecated, use github-private-key
     required: false
 
   app-directory:
@@ -92,7 +96,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - if: ${{ !inputs.token && !(inputs.github-app-id && inputs.github-app-private-key) }}
+    - if: ${{ !inputs.token && !(inputs.github-app-id && (inputs.github-private-key || inputs.github-app-private-key)) }}
       shell: bash
       run: |
         # Validate token or github-app inputs
@@ -104,7 +108,7 @@ runs:
       uses: actions/create-github-app-token@v1
       with:
         app-id: ${{ inputs.github-app-id }}
-        private-key: ${{ inputs.github-app-private-key }}
+        private-key: ${{ inputs.github-private-key || inputs.github-app-private-key }}
         repositories: platform,stackctl
 
     - id: token


### PR DESCRIPTION
I made a naming mistake. I thought I new better, but I did not.

I thought, when I saw `app-id` as the official action's input, that was
`(app-)id`. It is the "Id" of an "App" after all, right?

So then, when I then saw their `private-key` input, I assumed they had a
historical accident, and it should be `(app-)private-key`. I decided to
"fix" this, by using `app-private-key` and `APP_PRIVATE_KEY` in any of
the names I controlled, including this input.

I now understand, through other documentation, actions, and various
naming conventions, that (for better or worse), GitHub's intent there is
actually `[github-]app-id`: it's an "`AppId`", not an "`Id` for an
`App`". I feel like this choice will forever cause problems, but it
seems to be what they did. And, of course, they are (so far)
internally-consistent with that intent by using `[github-]private-key`,
which is what I should've matched.

This PR begins the add-transition-remove cycle by adding
`github-private-key` here.
