### PR TITLE
chore: use new input name for actions/create-github-app-token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
       if: ${{ !inputs.token }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.github-app-id }}
+        client-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-private-key || inputs.github-app-private-key }}
         repositories: platform,stackctl
 


### PR DESCRIPTION
Either are supported, but `app-id` is deprecated. We'll keep our own
input named "app" for now. Managing that rename ourselves feels annoying
with little value.
